### PR TITLE
Fix typo in task2 starter code in ARP_Attack.tex

### DIFF
--- a/category-network/ARP_Attack/ARP_Attack.tex
+++ b/category-network/ARP_Attack/ARP_Attack.tex
@@ -358,7 +358,7 @@ def spoof_pkt(pkt):
 
          if pkt[TCP].payload:
              data = pkt[TCP].payload.load  # The original payload data
-             newdata = data   # No change is nade in this sample code
+             newdata = data   # No change is made in this sample code
 
              send(newpkt/newdata)
          else:


### PR DESCRIPTION
Typo found in Task2 starter code in ARP_Attack.tex