### PR TITLE
FIx a typo in Sniffing_Spoofing.tex

### DIFF
--- a/category-network/Sniffing_Spoofing/Sniffing_Spoofing.tex
+++ b/category-network/Sniffing_Spoofing/Sniffing_Spoofing.tex
@@ -252,7 +252,7 @@ from scapy.all import *
 def print_pkt(pkt):
   pkt.show()
 
-pkt = sniff(iface='br-c93733e9f913', filter='icmp', prn=spoof_pkt)
+pkt = sniff(iface='br-c93733e9f913', filter='icmp', prn=print_pkt)
 \end{lstlisting}
 
 


### PR DESCRIPTION
For Python code in sniffer.py, the `prn=spoof_pkt` should be changed to `prn=print_pkt`.