### PR TITLE
Fix typos in DNS_Remote.tex

### DIFF
--- a/category-network/DNS_Remote/DNS_Remote.tex
+++ b/category-network/DNS_Remote/DNS_Remote.tex
@@ -295,7 +295,7 @@ it will not take too many tries before the attacker can succeed.
 
 
 However, the above hypothetical attack has overlooked the cache effect.
-In reality, if the attacker is not fortunately enough to make a correct guess before
+In reality, if the attacker is not fortunate enough to make a correct guess before
 the real response packet arrives, correct information will be cached 
 by the DNS server for a while. This caching effect makes it impossible
 for the attacker to forge another response regarding the same 
@@ -410,7 +410,7 @@ nameservers (it should be noted that there are multiple
 nameservers for this domain).
 
 Students can use Scapy to implement this task. The following 
-code snippet constructs an DNS response packet that includes 
+code snippet constructs a DNS response packet that includes 
 a question section, an answer section, and an NS section. 
 In the sample code, we use \texttt{+++} as placeholders; 
 students need to replace them with the correct values 


### PR DESCRIPTION
Typos found in DNS_Remote.tex