### PR TITLE
Fix machine naming in old_Firewall.tex task 3

### DIFF
--- a/category-network/Firewall/old_Firewall.tex
+++ b/category-network/Firewall/old_Firewall.tex
@@ -225,7 +225,8 @@ behind a firewall (i.e., inside the company or school's network), and Machine B
 is outside of the firewall.
 Typically, there is a dedicated machine that runs the firewall, but
 in this task, for the sake of convenience, you can run the firewall 
-on Machine A.
+on Machine A. Note: If you are using 3 VMs, run the firewall on both Machine A
+(apollo) and Machine C (work) to simulate that both are behind the firewall.
 You can use {\tt iptables} to set up the following
 two firewall rules:
 
@@ -276,20 +277,24 @@ you can try block these IPs, instead of Facebook.
 \label{firewall:fig:sshtunnel}
 \end{figure}
  
-
+The scenario depicts the need to telnet to a machine called \texttt{"work"} from a machine called
+\texttt{"home"}. However the firewall blocks all incoming traffic except ssh to a machine called
+Apollo.
+If you are using 3 VMs, you will be attempting telnet from Machine B (home) to Machine C (work)
+through the firewall.
 To bypass the firewall, we can establish an SSH tunnel between
 Machine A and B, so all the telnet traffic will go through this tunnel
 (encrypted), evading the inspection. Figure~\ref{firewall:fig:sshtunnel}
 illustrates how the tunnel works. 
 The following command 
-establishes an SSH tunnel between the localhost (port 8000) and 
-machine B (using the default port 22); when packets come out of B's end, it will
+establishes an SSH tunnel between the localhost, machine B outside the firewall (port 8000) and 
+machine A (using the default port 22); when packets come out of B's end, it will
 be forwarded to Machine C's port 23 (\telnet port). If you only have two VMs,
 you can use one VM for both Machine B and Machine C.
 
 
 \begin{lstlisting}
-$ ssh -L 8000:Machine_C_IP:23  seed@Machine_B_IP
+$ ssh -L 8000:Machine_C_IP:23  seed@Machine_A_IP
 
 // We can now telnet to Machine C via the tunnel:
 $ telnet localhost 8000
@@ -298,7 +303,7 @@ $ telnet localhost 8000
 When we \telnet to \texttt{localhost}'s port \texttt{8000},  
 SSH will transfer all our TCP packets from
 one end of the tunnel on \texttt{localhost:8000} to the other end of the tunnel
-on Machine B; from there,
+on Machine A; from there,
 the packets will be forwarded to \texttt{Machine\_C:23}. Replies from Machine C will
 take a reverse path, and eventually reach our telnet client.
 Essentially, we are able to telnet to Machine C.


### PR DESCRIPTION
My school is using the old_Firewall.tex and I found parts in Task 3 that could be edited to improve clarity. I referenced the slides in [SEED resources - Network Security Firewall](https://www.handsonsecurity.net/resources.html) and found that the explanations differ from the lab. I attempted to make some edits based on my understanding from the slides and what was mentioned in the lab tasks and propose the fixes in this PR.

Context:
The Task mentions the following initially

> You need two VMs A and B for this task (three will be better). Machine A is running behind a firewall (i.e., inside the company or school's network), and Machine B is outside of the firewall.


This implies that Machine B is the "home" machine. For this lab since there is an SSH tunnel between B and A later, A is assumed to be  "Apollo" (to be consistent with the diagram in the SEED resources slides).

If there is a third machine, Machine C, this will then be the Telnet Server or the "work" machine which is also behind the company/school network.

The scenario as per the slides would be a user who works from home (on Machine B) who wants to telnet to his work machine (Machine C), and has to establish an SSH tunnel with Machine A (Apollo). If students have only 2 VMs then Machine B and Machine C would be the same.

Hence, based on this, some of the explanations in Task 3 need to be changed which are highlighted in this PR. I followed the [SEED resources - Network Security Firewall slides](https://www.handsonsecurity.net/resources.html) as the source of truth.