### PR TITLE
Corrected destination address

### DIFF
--- a/category-network/Firewall/Firewall.tex
+++ b/category-network/Firewall/Firewall.tex
@@ -861,7 +861,7 @@ your observation. How long is the TCP connection state be kept?
 # nc -l 9090
 
 // On 10.9.0.5, send out TCP packets 
-# nc 10.9.0.5 9090
+# nc 192.168.60.5 9090
 <type something, then hit return>
 \end{lstlisting}
 


### PR DESCRIPTION
The TCP server is started on 192.168.60.5, so the destination address should be 192.168.60.5 when sending packets from 10.9.0.5, not 10.9.0.5.