### PR TITLE
Update apache_sql_injection.conf

### DIFF
--- a/category-web/Web_SQL_Injection/Labsetup/image_www/apache_sql_injection.conf
+++ b/category-web/Web_SQL_Injection/Labsetup/image_www/apache_sql_injection.conf
@@ -1,4 +1,4 @@
 <VirtualHost *:80>
         DocumentRoot /var/www/SQL_Injection
-        ServerName   www.seed-server.com
+        ServerName   www.SeedLabSQLInjection.com
 </VirtualHost>


### PR DESCRIPTION
SQL-Injection lab is currently broken. apache_sql_injection.conf uses ServerName "www.seed-server.com" instead of "www.SeedLabSQLInjection.com". As a result, only the Apache's default page (index.html) will be opened after docker-compose build & up.