### PR TITLE
fix($complie): change images in docker-compose.yml

### DIFF
--- a/category-network/Firewall/Labsetup/docker-compose.yml
+++ b/category-network/Firewall/Labsetup/docker-compose.yml
@@ -51,8 +51,7 @@ services:
                  "
 
     Host3:
-      # image: handsonsecurity/seed-ubuntu:large
-        image: seed-router-image
+        image: handsonsecurity/seed-ubuntu:large
         container_name: host3-192.168.60.7
         tty: true
         cap_add:
@@ -71,7 +70,7 @@ services:
 
     Router:
         build: router
-        image: seed-router-image 
+        image: handsonsecurity/seed-ubuntu:large
         container_name: seed-router
         tty: true
         cap_add:


### PR DESCRIPTION
Couple of images are wrong in docker-compose.yml:
```
Host3:
      # image: handsonsecurity/seed-ubuntu:large
        image: seed-router-image
        container_name: host3-192.168.60.7
        tty: true
        cap_add:
                - ALL
        volumes:
                - ./volumes:/volumes
        networks:
            net-192.168.60.0:
                ipv4_address: 192.168.60.7
        command: bash -c "
                      ip route del default  &&
                      ip route add default via 192.168.60.11  &&
                      /etc/init.d/openbsd-inetd start  &&
                      tail -f /dev/null
                 "
    Router:
        build: router
        image: seed-router-image 
        container_name: seed-router
        tty: true
        cap_add:
                - ALL
        sysctls:
                - net.ipv4.ip_forward=1
        volumes:
                - ./volumes:/volumes
        networks:
            net-10.9.0.0:
                ipv4_address: 10.9.0.11
            net-192.168.60.0:
                ipv4_address: 192.168.60.11
        command: bash -c "
                      ip route del default  &&
                      ip route add default via 10.9.0.1 &&
                      /etc/init.d/openbsd-inetd start  &&
                      tail -f /dev/null
                 "
```
There is no image for `seed-router-image` on Docker Hub
They should be changed to `handsonsecurity/seed-ubuntu:large`