### PR TITLE
Adding a solution for Apple Silicon machines can't find gcc-12 compiler

### DIFF
--- a/lab-setup/apple-arm/Notes/Network_Security.md
+++ b/lab-setup/apple-arm/Notes/Network_Security.md
@@ -5,36 +5,36 @@
 The setup is fine, however, the behaviors of ICMP redirect
 on Ubuntu 22.04 is slightly different from that on Ubuntu 20.04.
 In both versions, the ICMP redirect packets must include
-the original packet that triggers the redirect, and the sender 
-is supposed to verify that the included packet is the same 
-as the original one. However, how strictly the checking is 
-conducted is different for these two OS versions; 
-Ubuntu 22.04 seems to be more strict. 
+the original packet that triggers the redirect, and the sender
+is supposed to verify that the included packet is the same
+as the original one. However, how strictly the checking is
+conducted is different for these two OS versions;
+Ubuntu 22.04 seems to be more strict.
 Therefore, on Ubuntu 20.04, we can just directly spoof an
-ICMP redirect packet, but on Ubuntu 22.04, we need to 
-capture the original packet. 
+ICMP redirect packet, but on Ubuntu 22.04, we need to
+capture the original packet.
 We can use sniff and spoof technique to do this:
-we can monitor the LAN via packet sniffing. Whenever we see an 
+we can monitor the LAN via packet sniffing. Whenever we see an
 ICMP echo request, we spoof an ICMP redirect packet.
 
 ## TCP Lab
 
-To compile the `synflood.c` program, we need to use the static 
-binding (`gcc -static`), or we will see an issue caused by missing libraries. 
-This is a minor issue. 
+To compile the `synflood.c` program, we need to use the static
+binding (`gcc -static`), or we will see an issue caused by missing libraries.
+This is a minor issue.
 
 ## DNS Remote Attack
 
 Tried the attack. The program works, but the attack is not successful.
-Need to investigate further. 
+Need to investigate further.
 
 
 ## DNS Rebinding Attack
 
-It seems that the we have trouble running the flask server due to the 
-version. We need to upgrade the flask container by running the 
-following command. The one used in the original `Dockerfile` is 
-version `1.1.1`. Further testing is needed. 
+It seems that the we have trouble running the flask server due to the
+version. We need to upgrade the flask container by running the
+following command. The one used in the original `Dockerfile` is
+version `1.1.1`. Further testing is needed.
 
 ```
 pip3 install flask --upgrade
@@ -44,20 +44,25 @@ Newer version of Firefox enables DNS over HTTPS. Therefore, the DNS
 resolution may not go through the local DNS server or the `/etc/hosts`
 file. This will create issues for many SEED labs. We need to disable it.
 Go to `Setting` -> `Privacy & Security`, and go to `DNS over HTTPS`, and select
-`off`. 
+`off`.
 
 
-## Firewall Exploration Lab 
+## Firewall Exploration Lab
 
-The `dmesg` command in Ubuntu 22.04 requires the root privilege. This is 
+We need to install gcc-12 to compile a loadable kernel module.
+```
+sudo apt install gcc-12
+```
+
+The `dmesg` command in Ubuntu 22.04 requires the root privilege. This is
 different from Ubuntu 20.04.
 
 
 ## Morris Worm Lab
 
-The Internet emulator works, but since the attack depends on the 
+The Internet emulator works, but since the attack depends on the
 buffer overflow attack, the shellcode in the solution needs to
-change. We are still working on revising 
+change. We are still working on revising
 the buffer overflow attack lab for ARM. When that is done,
 this lab should work. Here are some minor issues:
 
@@ -66,7 +71,6 @@ this lab should work. Here are some minor issues:
   has a problem, but if we build 10 images at a time (like the command
   in `z_start.sh`, there is no problem.
 - On Apple VM, we don't need the `z_start.sh` to start the containers.
-  Simply running `dcup` should work. 
-- On AMD machine, it is opposite: `dcbuild` is fine, but we need to use 
-  `z_start.sh` to start the containers. 
-
+  Simply running `dcup` should work.
+- On AMD machine, it is opposite: `dcbuild` is fine, but we need to use
+  `z_start.sh` to start the containers.


### PR DESCRIPTION
Adding a solution for Apple Silicon machines can't find gcc-12 compiler in Firewall Exploration Lab.