### PR TITLE
fix: Arm MySQL version numbers

### DIFF
--- a/category-web/Web_CSRF_Elgg/Labsetup-arm/image_mysql/Dockerfile
+++ b/category-web/Web_CSRF_Elgg/Labsetup-arm/image_mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:8.0.37
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV MYSQL_ROOT_PASSWORD=dees

--- a/category-web/Web_SQL_Injection/Labsetup-arm/image_mysql/Dockerfile
+++ b/category-web/Web_SQL_Injection/Labsetup-arm/image_mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:8.0.37
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV MYSQL_ROOT_PASSWORD=dees

--- a/category-web/Web_XSS_Elgg/Labsetup-arm/image_mysql/Dockerfile
+++ b/category-web/Web_XSS_Elgg/Labsetup-arm/image_mysql/Dockerfile
@@ -1,4 +1,4 @@
-FROM mysql
+FROM mysql:8.0.37
 ARG DEBIAN_FRONTEND=noninteractive
 
 ENV MYSQL_ROOT_PASSWORD=dees


### PR DESCRIPTION
This update to the MySQL Docker image https://github.com/docker-library/official-images/commit/35493c0c6d65382833eb85f1e598fd0d6ab3eaec changed `latest` to 8.4, which isn't compatible with the configuration in the labs. This PR specifies a fixed MySQL version in the Dockerfiles to fix this problem and prevent it happening again in the future.