### PR TITLE
remove installation of docker-mac-net-connect part in Apple-arm document

### DIFF
--- a/lab-setup/apple-arm/seedvm-fusion.md
+++ b/lab-setup/apple-arm/seedvm-fusion.md
@@ -55,20 +55,6 @@ If after installing homebrew you are not able to access brew, run the following 
 ```eval $(/opt/homebrew/bin/brew shellenv)```
 
 
-### Step 1.2: Install ```docker-mac-net-connect```
-
-This is required to connect the docker container to the host network. 
-To install `docker-mac-net-connect`, open the terminal and run the following command.
-
-```brew install chipmk/tap/docker-mac-net-connect```
-
-And then start the service using the following command.
-
-```sudo brew services start chipmk/tap/docker-mac-net-connect```
-
-![brew services start](Figs/brew-services-start.png)
-
-
 
 ## <a id="install-fusion"></a>Step 2: Install VMware Fusion Player
 


### PR DESCRIPTION
In step 1.2 I fail to install `docker-mac-net-connect` from brew with: 
```
brew install chipmk/tap/docker-mac-net-connect
```
Running into the following error:
```
# github.com/chipmk/docker-mac-net-connect
link: golang.org/x/net/internal/socket: invalid reference to syscall.recvmsg
```
After investigating, it is because the new version Go 1.23 broke access to internal symbols. The detail can be checked in 
[invalid reference to syscall.recvmsg ](https://github.com/chipmk/docker-mac-net-connect/issues/39). As of this writing, there is no official solution.

To verify whether the `docker-mac-net-connect` is necessary for SEED Lab, I install an VMware Fusion without installing `docker-mac-net-connect`. The SEED Lab setup and installation work well. For labs running stage, I tested the XSS Lab. it can successfully access the Elgg web page. I also create a hybrid network using the SEED Emulator. The nodes can access outside network testing by `ping 8.8.8.8`.

So far, I believe the `docker-mac-net-connect` may be unnecessary for SEED Lab. Thus I remove the installation of docker-mac-net-connect part from Apple-arm document.

