### PR TITLE
fix: server generate_random_env prototype

### DIFF
--- a/category-software/Buffer_Overflow_Server/Labsetup-arm/Labsetup/server-code/server.c
+++ b/category-software/Buffer_Overflow_Server/Labsetup-arm/Labsetup/server-code/server.c
@@ -14,7 +14,7 @@
 
 int socket_bind(int port);
 int server_accept(int listen_fd, struct sockaddr_in *client);
-char **generate_random_env();
+char **generate_random_env(int length);
 
 void main()
 {

--- a/category-software/Buffer_Overflow_Server/Labsetup/server-code/server.c
+++ b/category-software/Buffer_Overflow_Server/Labsetup/server-code/server.c
@@ -14,7 +14,7 @@
 
 int socket_bind(int port);
 int server_accept(int listen_fd, struct sockaddr_in *client);
-char **generate_random_env();
+char **generate_random_env(int length);
 
 void main()
 {


### PR DESCRIPTION
Declaring conflicted prototype is deprecated in all versions of C and is not supported in C23.

Newer version of gcc will complain with
```
gcc -o server server.c
server.c: In function ‘main’:
server.c:63:52: error: too many arguments to function ‘generate_random_env’; expected 0, have 1
   63 |             execle(PROGRAM, PROGRAM, (char *)NULL, generate_random_env(random_n));
      |                                                    ^~~~~~~~~~~~~~~~~~~ ~~~~~~~~
server.c:17:8: note: declared here
   17 | char **generate_random_env();
      |        ^~~~~~~~~~~~~~~~~~~
server.c: At top level:
server.c:124:8: error: conflicting types for ‘generate_random_env’; have ‘char **(int)’
  124 | char **generate_random_env(int length)
      |        ^~~~~~~~~~~~~~~~~~~
server.c:17:8: note: previous declaration of ‘generate_random_env’ with type ‘char **(void)’
   17 | char **generate_random_env();
      |        ^~~~~~~~~~~~~~~~~~~
```